### PR TITLE
Shorter path to get to Pak Shui Wun

### DIFF
--- a/_pages/places/off_campus/Pak_Shui_Wun.md
+++ b/_pages/places/off_campus/Pak_Shui_Wun.md
@@ -7,7 +7,7 @@ A very nice beach next to [HKUST](/_pages/places/chapter0/HKUST_content.md)'s [S
 > Ship:
 ![Ship in Pak Shui Wun](/media/ship.jpg)
 
-It can be accessed through the staircase in [North Gate](../chapter0/North_Gate.md) next to the station of minibus route [12](/_pages/Transports/Transports.md).
+It can be accessed through the staircase in [North Gate](../chapter0/North_Gate.md) next to the station of minibus route [12](/_pages/Transports/Transports.md). For a shorter path, you can also use the gate which is located to the left of UG HALL III. However, this gate is open until 6PM (heresay, source needed), unkown when it opens. The exact location is around [here](https://maps.app.goo.gl/xH39qAkjux3mgJTW9?g_st=aw).
 
 You may also see a 30m tall waterfall, especially during wet season on the trail to Pak Shui Wun.
 > The waterfall on the trail, hidden behind trees


### PR DESCRIPTION
There is another gate in front of hall III that can be used to go to Pak Shui Wun beach, It's a shorter route as well